### PR TITLE
Update to SimpleSolvers 0.10 and revisit solver defaults

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ GeometricSolutions = "0.6.3"
 LinearAlgebra = "1"
 OffsetArrays = "1"
 SafeTestsets = "0.1.0"
-SimpleSolvers = "0.9"
+SimpleSolvers = "0.10"
 Unicode = "1"
 julia = "1.10"
 

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -44,7 +44,7 @@ function GeometricIntegrator(
     caches=CacheDict(problem, method),
     options...
 )
-    solver = initsolver(solvermethod, method, caches; (length(options) == 0 ? default_options(method) : options)...)
+    solver = initsolver(solvermethod, method, caches; merge(default_options(method), options)...)
     GeometricIntegrator(problem, method, caches, solver, iguess, SolverState(solver))
 end
 

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -3,9 +3,6 @@ default_linesearch(method=nothing) = Backtracking()
 
 default_options(method=nothing) = (
     min_iterations=1,
-    f_abstol=8eps(),
-    # linesearch=default_linesearch(method),
-    # verbosity=2,
 )
 
 initsolver(::SolverMethod, ::GeometricMethod, ::CacheDict; kwargs...) = NoSolver()

--- a/test/euler_tests.jl
+++ b/test/euler_tests.jl
@@ -18,10 +18,12 @@ ref = exact_solution(ode)
     err = relative_maximum_error(sol, ref)
     @test err.q < 5E-2
 
-    sol = integrate(ode, ImplicitEuler();
-        min_iterations=1,
-        x_abstol=2eps(),
-        f_abstol=2eps(),
+    # ImplicitEuler with explicit (tight but reachable) solver tolerances.
+    # min_iterations is retained via merge with default_options, so it need not be
+    # restated here; a converged solve is now silent, so assert no solver warnings.
+    sol = @test_nowarn integrate(ode, ImplicitEuler();
+        x_abstol=1e-12,
+        f_abstol=1e-12,
     )
     err = relative_maximum_error(sol, ref)
     @test err.q < 5E-2

--- a/test/implicit_euler_tests.jl
+++ b/test/implicit_euler_tests.jl
@@ -55,12 +55,10 @@ using ..HarmonicOscillator
         err = relative_maximum_error(sol, ref)
         @test err.q < 5E-2
 
-        # Test with tighter solver tolerances
-        sol_tight = integrate(ode, ImplicitEuler();
-            min_iterations=1,
+        # Test with tighter solver tolerances.
+        sol_tight = @test_nowarn integrate(ode, ImplicitEuler();
             x_abstol=1e-12,
             f_abstol=1e-12,
-            max_iterations=100
         )
         err_tight = relative_maximum_error(sol_tight, ref)
         @test err_tight.q < 5E-2
@@ -103,15 +101,14 @@ using ..HarmonicOscillator
     @testset "Convergence Properties" begin
         ode = odeproblem()
 
-        # Test that very loose tolerances still converge
+        # Test that very loose tolerances still converge.
         sol_loose = integrate(ode, ImplicitEuler();
             x_abstol=1e-4,
             f_abstol=1e-4,
-            max_iterations=50
         )
         @test all(x -> all(isfinite, x), sol_loose.q)
 
-        # Test that we can increase max iterations
+        # Test that max_iterations is still accepted as a solver option
         sol_many_iter = integrate(ode, ImplicitEuler();
             max_iterations=200
         )


### PR DESCRIPTION
Bumps the `SimpleSolvers` compat to `0.10` and adjusts the framework solver defaults to match the warning/criteria changes in [JuliaGNI/SimpleSolvers.jl#171](https://github.com/JuliaGNI/SimpleSolvers.jl/pull/171).

## Solver defaults (`src/solvers.jl`, `src/integrator.jl`)

- **Drop `f_abstol` from `default_options`.** `8eps() ≈ 1.78e-15` sat below the round-off floor of essentially every non-trivial residual, so the absolute criterion was unreachable and Newton ran to its iteration limit. The framework now relies on SimpleSolvers' relative and successive-change criteria — matching SimpleSolvers' own default of `f_abstol = 0`, the more honest default for a framework that cannot know the caller's residual scale.
- **Merge instead of replace.** `merge(default_options(method), options)` replaces the old `length(options) == 0 ? default_options(method) : options`, so passing any option no longer silently discards the remaining defaults. This matters most for `min_iterations = 1`, which now controls whether a step is taken at all (SimpleSolvers tests its stopping criteria before the first step).

`verbosity` was considered for `default_options` but deliberately left out; callers set it themselves when needed.

## Test tolerances (`test/euler_tests.jl`, `test/implicit_euler_tests.jl`)

Cleaned up the hand-tuning that the above makes unnecessary:

- Relaxed the below-floor `f_abstol`/`x_abstol = 2eps()` to a reachable `1e-12`.
- Removed `max_iterations` bounds that existed to cap a possibly-non-converging solve — stall detection handles that now. Kept the one `max_iterations = 200` block whose purpose is to verify the option is accepted.
- Dropped now-redundant `min_iterations = 1` restatements (retained via the merge).
- Wrapped converged solves in `@test_nowarn` as a silence tripwire, matching the pattern used in GeometricProblems.

## Verification

Full test suite passes on `SimpleSolvers v0.10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)