### PR TITLE
Update for SimpleSolvers 0.11.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricIntegratorsBase"
 uuid = "71212ab4-08a2-48eb-a02b-4cbad0e9c44a"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [workspace]
@@ -23,7 +23,7 @@ GeometricSolutions = "0.6.3"
 LinearAlgebra = "1"
 OffsetArrays = "1"
 SafeTestsets = "0.1.0"
-SimpleSolvers = "0.10"
+SimpleSolvers = "0.11"
 Unicode = "1"
 julia = "1.10"
 

--- a/src/GeometricIntegratorsBase.jl
+++ b/src/GeometricIntegratorsBase.jl
@@ -19,7 +19,7 @@ import GeometricBase: integrate, integrate!
 import GeometricBase: periodic, verifyrange
 import GeometricBase: AbstractVariable, AbstractScalarVariable, AbstractStateVariable, TimeVariable
 import GeometricBase: NoSolver
-import SimpleSolvers: NonlinearSolverMethod
+import SimpleSolvers: NonlinearSolverException, NonlinearSolverMethod
 
 
 # The problem unions of GeometricEquations also cover the constrained variants, that is

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -45,11 +45,17 @@ function integrate!(sol::GeometricSolution, int::AbstractIntegrator, n₁::Int, 
         # warn, and return what has been computed so far. The `break` happens before the `copy!`,
         # so `sol` holds valid data up to `n-1`. Only this one exception type is caught — anything
         # else is a bug and must not be masked.
+        #
+        # The warning has to say where the valid data ends, because nothing in `sol` marks it: the
+        # entries from `n` on are the zeros `Solution` allocated, which for most problems is
+        # indistinguishable from computed data. The NaN branch below does not need to say so — it
+        # copies first, so the offending entry carries a NaN a caller can see.
         try
             integrate!(solstep, int)
         catch e
             e isa NonlinearSolverException || rethrow()
-            @warn "Nonlinear solver failed at timestep n=$(n): $(e.msg)"
+            @warn "Nonlinear solver failed at timestep n=$(n): $(e.msg). " *
+                  "The solution is valid up to n=$(n-1); later entries were never computed."
             break
         end
 

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -35,7 +35,23 @@ function integrate!(sol::GeometricSolution, int::AbstractIntegrator, n₁::Int, 
         reset!(solstep, timesteps(sol)[n])
 
         # integrate one step
-        integrate!(solstep, int)
+        #
+        # A step whose nonlinear solve breaks down throws rather than returning a bad iterate:
+        # since SimpleSolvers 0.11 a non-finite *direction* is rejected outright, where it used to
+        # be handed to a damping that could not shorten it (`Inf * nan_factor` is `Inf`) and so
+        # stalled silently. Left to propagate, that exception would discard the whole trajectory,
+        # because `integrate(problem, method)` allocates the solution internally and the caller
+        # never sees it. So it is treated exactly as the NaN check below treats a bad iterate:
+        # warn, and return what has been computed so far. The `break` happens before the `copy!`,
+        # so `sol` holds valid data up to `n-1`. Only this one exception type is caught — anything
+        # else is a bug and must not be masked.
+        try
+            integrate!(solstep, int)
+        catch e
+            e isa NonlinearSolverException || rethrow()
+            @warn "Nonlinear solver failed at timestep n=$(n): $(e.msg)"
+            break
+        end
 
         # copy solution from solution step to solution
         copy!(sol, curstate, n)

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -44,7 +44,10 @@ function integrate!(sol::GeometricSolution, int::AbstractIntegrator, n₁::Int, 
         # never sees it. So it is treated exactly as the NaN check below treats a bad iterate:
         # warn, and return what has been computed so far. The `break` happens before the `copy!`,
         # so `sol` holds valid data up to `n-1`. Only this one exception type is caught — anything
-        # else is a bug and must not be masked.
+        # else is a bug and must not be masked. `NonlinearSolverException` is named in the explicit
+        # `import SimpleSolvers:` list rather than picked up from `using`, so the dependency does not
+        # rest on it staying exported, and `e.msg` is reached only after the `isa` has established
+        # that the field is there.
         #
         # The warning has to say where the valid data ends, because nothing in `sol` marks it: the
         # entries from `n` on are the zeros `Solution` allocated, which for most problems is

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -1,9 +1,36 @@
 
 default_linesearch(method=nothing) = Backtracking()
 
+# `Backtracking()` is always `Backtracking{Float64}`, so a `Float32` integration makes the
+# `Linesearch` constructor do a `change_precision` the caller could have avoided by building the
+# method at the working type in the first place. Both methods are kept: the untyped one is the
+# downstream hook (`GeometricIntegrators` calls it for DIRK) and its signature must not change.
+#
+# `expand = true` is deliberately not set. The expansion phase of `Backtracking` is opt-in
+# upstream because it costs a merit evaluation — a full residual evaluation here — on a direction
+# whose scale is wrong, and gains nothing on one whose scale is right: a Newton step already sits
+# at its model minimum. Every method in this package solves with `Newton()`.
+default_linesearch(::Type{T}, method=nothing) where {T} = Backtracking(T)
+
 default_options(method::GeometricMethod, problem::GeometricProblem) = (
     min_iterations=1,
-    f_abstol=max(8, solversize(method, problem)) * eps(datatype(problem))
+    f_abstol=max(8, solversize(method, problem)) * eps(datatype(problem)),
+    # Bound a solve whose residual sits on a floor above `f_abstol` while its iterate keeps
+    # moving normally: no convergence branch fires, `max_stalls` cannot see it (the step is not
+    # small), and the solve spends `max_iterations` — 1000 by default — on *every* time step.
+    #
+    # 50 is the conservative point. An iteration converging linearly with rate ρ improves by ρ^W
+    # over a window W, so at SimpleSolvers' `f_stall_factor = 0.5` a window of 50 gives up only on
+    # ρ > 2^(-1/50) ≈ 0.986, i.e. on a residual that is essentially flat — which no Newton solve
+    # on these residuals is. It also stays above `SimpleSolvers.F_STALL_REPORT_MINIMUM`, below
+    # which SimpleSolvers itself holds the no-progress proportion to be no evidence of anything;
+    # giving up on less than the package will report on would be incoherent.
+    #
+    # Giving up and converging remain mutually exclusive (`no_progress` is gated on
+    # `!residual_small`), the solve still reports the residual it achieved against the tolerance
+    # it was asked for, and `default_options` is merged rather than replaced, so a caller who
+    # disagrees overrides it with one keyword.
+    f_stall_window=50,
 )
 
 initsolver(::SolverMethod, ::GeometricMethod, ::CacheDict; kwargs...) = NoSolver()

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -12,13 +12,20 @@ hook (`GeometricIntegrators` calls it for DIRK) and its signature must not chang
 Neither form is called inside this package. They are the hook downstream methods reach for, which
 is why the tests assert both signatures and the choice below.
 
+`T` is constrained so that the typed method cannot quietly intercept a call meant for the untyped
+one: a caller passing a *method type* rather than an instance — `default_linesearch(ImplicitEuler)`
+— falls through to the untyped hook and gets a `Backtracking{Float64}`, as it did before the typed
+method existed, rather than an error from inside `Backtracking`. `Real` rather than `AbstractFloat`,
+because `Backtracking` is buildable at any real type that `T(::Float64)` accepts, which includes
+the `ForwardDiff.Dual` a caller differentiating through an integration would arrive with.
+
 `expand = true` is deliberately not set. The expansion phase of `Backtracking` is opt-in upstream
 because it costs a merit evaluation — a full residual evaluation here — on a direction whose scale
 is wrong, and gains nothing on one whose scale is right: a Newton step already sits at its model
 minimum. Every method in this package solves with `Newton()`.
 """
 default_linesearch(method=nothing) = Backtracking()
-default_linesearch(::Type{T}, method=nothing) where {T<:Number} = Backtracking(T)
+default_linesearch(::Type{T}, method=nothing) where {T<:Real} = Backtracking(T)
 
 """
 The window, in iterations, after which a nonlinear solve that is not descending towards `f_abstol`

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -1,36 +1,54 @@
 
-default_linesearch(method=nothing) = Backtracking()
+"""
+    default_linesearch([T,] method=nothing)
 
-# `Backtracking()` is always `Backtracking{Float64}`, so a `Float32` integration makes the
-# `Linesearch` constructor do a `change_precision` the caller could have avoided by building the
-# method at the working type in the first place. Both methods are kept: the untyped one is the
-# downstream hook (`GeometricIntegrators` calls it for DIRK) and its signature must not change.
-#
-# `expand = true` is deliberately not set. The expansion phase of `Backtracking` is opt-in
-# upstream because it costs a merit evaluation — a full residual evaluation here — on a direction
-# whose scale is wrong, and gains nothing on one whose scale is right: a Newton step already sits
-# at its model minimum. Every method in this package solves with `Newton()`.
-default_linesearch(::Type{T}, method=nothing) where {T} = Backtracking(T)
+The line search a `method` uses by default, built at the working type `T` where one is given.
+
+`Backtracking()` is always `Backtracking{Float64}`, so a `Float32` integration makes the
+`Linesearch` constructor do a `change_precision` the caller could have avoided by building the
+method at the working type in the first place. Both forms exist: the untyped one is the downstream
+hook (`GeometricIntegrators` calls it for DIRK) and its signature must not change.
+
+Neither form is called inside this package. They are the hook downstream methods reach for, which
+is why the tests assert both signatures and the choice below.
+
+`expand = true` is deliberately not set. The expansion phase of `Backtracking` is opt-in upstream
+because it costs a merit evaluation — a full residual evaluation here — on a direction whose scale
+is wrong, and gains nothing on one whose scale is right: a Newton step already sits at its model
+minimum. Every method in this package solves with `Newton()`.
+"""
+default_linesearch(method=nothing) = Backtracking()
+default_linesearch(::Type{T}, method=nothing) where {T<:Number} = Backtracking(T)
+
+"""
+The window, in iterations, after which a nonlinear solve that is not descending towards `f_abstol`
+is given up on; the `f_stall_window` of [`default_options`](@ref).
+
+Without it, a solve whose residual sits on a floor above `f_abstol` while its iterate keeps moving
+normally is invisible: no convergence branch fires, `max_stalls` cannot see it (the step is not
+small), and the solve spends `max_iterations` — 1000 by default — on *every* time step.
+
+50 is the conservative point: it gives up only on a residual that is essentially flat, which no
+`Newton()` solve on these residuals is, and it stays above `SimpleSolvers.F_STALL_REPORT_MINIMUM`,
+below which SimpleSolvers itself holds the no-progress proportion to be no evidence of anything.
+See `SimpleSolvers.F_STALL_WINDOW` for the linear rate a given window corresponds to at a given
+`f_stall_factor`.
+
+The one case it is *not* conservative for is a solve that converges linearly at a rate close to
+that threshold — a `Picard()` fixed-point iteration on a stiff problem near its convergence limit,
+say. Every method in this package uses `Newton()`, but `default_options` is reached with whatever
+`solvermethod` the caller hands to `GeometricIntegrator`, so such a caller has to raise this.
+"""
+const DEFAULT_F_STALL_WINDOW = 50
 
 default_options(method::GeometricMethod, problem::GeometricProblem) = (
     min_iterations=1,
     f_abstol=max(8, solversize(method, problem)) * eps(datatype(problem)),
-    # Bound a solve whose residual sits on a floor above `f_abstol` while its iterate keeps
-    # moving normally: no convergence branch fires, `max_stalls` cannot see it (the step is not
-    # small), and the solve spends `max_iterations` — 1000 by default — on *every* time step.
-    #
-    # 50 is the conservative point. An iteration converging linearly with rate ρ improves by ρ^W
-    # over a window W, so at SimpleSolvers' `f_stall_factor = 0.5` a window of 50 gives up only on
-    # ρ > 2^(-1/50) ≈ 0.986, i.e. on a residual that is essentially flat — which no Newton solve
-    # on these residuals is. It also stays above `SimpleSolvers.F_STALL_REPORT_MINIMUM`, below
-    # which SimpleSolvers itself holds the no-progress proportion to be no evidence of anything;
-    # giving up on less than the package will report on would be incoherent.
-    #
     # Giving up and converging remain mutually exclusive (`no_progress` is gated on
     # `!residual_small`), the solve still reports the residual it achieved against the tolerance
     # it was asked for, and `default_options` is merged rather than replaced, so a caller who
-    # disagrees overrides it with one keyword.
-    f_stall_window=50,
+    # disagrees overrides this with one keyword.
+    f_stall_window=DEFAULT_F_STALL_WINDOW,
 )
 
 initsolver(::SolverMethod, ::GeometricMethod, ::CacheDict; kwargs...) = NoSolver()

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -2,8 +2,9 @@ using GeometricIntegratorsBase
 using Test
 
 using GeometricIntegratorsBase: ODEMethod
-using GeometricIntegratorsBase: equations, timestep
+using GeometricIntegratorsBase: equations, method, timestep
 using GeometricEquations: GeometricProblem, ODEProblem
+using SimpleSolvers: NonlinearSolverException
 
 import GeometricIntegratorsBase: integrate_step!
 
@@ -31,10 +32,51 @@ sol = integrate(odeproblem(), ExplicitEulerTest())
 # bad iterate. The time-stepping loop has to catch it, or `integrate` — which allocates the
 # solution internally — would discard the whole trajectory instead of the part that is valid.
 #
-# The vector field goes non-finite past a fixed time rather than blowing up gradually, so the step
-# at which the solve breaks down is pinned down (with a timestep of 0.1 and the stage time of the
-# implicit method at the end of the step, that is n = 4) instead of depending on how an overflow
-# happens to round.
+# The handling is tested directly first, on a method that throws at a chosen time. That pins down
+# which step fails, what the surviving steps hold, what the rest of the solution holds, and that
+# any other exception is rethrown — none of which then depend on how SimpleSolvers happens to
+# arrive at the non-finite direction it rejects. The end-to-end test below is the complement: it
+# checks that a real solve does reach that rejection.
+
+struct FailingTest{ET} <: ODEMethod
+    tfail::Float64
+    exception::ET
+end
+
+function integrate_step!(sol, hist, params, int::GeometricIntegrator{<:FailingTest,<:GeometricProblem})
+    # `reset!` sets `sol.t` to the time at the end of the step, so with a timestep of 0.1 and
+    # `tfail = 0.35` the first step to throw is n = 4
+    sol.t ≥ method(int).tfail && throw(method(int).exception)
+
+    # a doubling per step: the steps that survive a breakdown are then exactly checkable, and
+    # distinguishable from the zeros `Solution` allocates for the steps that never ran
+    sol.q .*= 2
+
+    return (
+        solution = sol,
+    )
+end
+
+failing = odeproblem(timespan = (0.0, 1.0), timestep = 0.1)
+
+sol_failing = @test_logs (:warn, r"Nonlinear solver failed at timestep n=4") match_mode = :any integrate(
+    failing, FailingTest(0.35, NonlinearSolverException("test breakdown")))
+
+# the steps before the breakdown hold what they computed, and the exception did not propagate
+@test all(n -> sol_failing.q[n] == 2^n .* sol_failing.q[0], 0:3)
+
+# the steps from the breakdown on were never computed, so they are still the allocated zeros —
+# which is what the warning has to say, since nothing in the solution itself marks the end
+@test all(n -> all(iszero, sol_failing.q[n]), 4:lastindex(sol_failing.q))
+
+# any other exception is a bug and must not be masked
+@test_throws ErrorException integrate(failing, FailingTest(0.35, ErrorException("not a solver failure")))
+
+
+# The complement: a real `Newton()` solve that does reach the rejection above. The vector field
+# goes non-finite past a fixed time rather than blowing up gradually, so the step at which the
+# solve breaks down is pinned down (with a timestep of 0.1 and the stage time of the implicit
+# method at the end of the step, that is n = 4) instead of depending on how an overflow rounds.
 function breakdown_v(v, t, q, params)
     v .= t ≥ 0.35 ? Inf : q
     nothing
@@ -44,5 +86,7 @@ breakdown = ODEProblem(breakdown_v, (0.0, 1.0), 0.1, [1.0, 0.0])
 
 sol_breakdown = @test_logs (:warn, r"Nonlinear solver failed at timestep n=4") match_mode = :any integrate(breakdown, ImplicitEuler())
 
-# the steps before the breakdown survive, and the exception did not propagate
-@test all(n -> all(isfinite, sol_breakdown.q[n]), 0:3)
+# the steps before the breakdown survive, and the exception did not propagate. asserting the exact
+# values rather than `isfinite`, because the zeros left behind by an early `break` are finite too:
+# implicit Euler on q̇ = q gives qₙ₊₁ = qₙ / (1 - h)
+@test all(n -> sol_breakdown.q[n] ≈ [1 / (1 - 0.1)^n, 0.0], 0:3)

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -3,7 +3,7 @@ using Test
 
 using GeometricIntegratorsBase: ODEMethod
 using GeometricIntegratorsBase: equations, timestep
-using GeometricEquations: GeometricProblem
+using GeometricEquations: GeometricProblem, ODEProblem
 
 import GeometricIntegratorsBase: integrate_step!
 
@@ -25,3 +25,24 @@ function integrate_step!(sol, hist, params, int::GeometricIntegrator{<:ExplicitE
 end
 
 sol = integrate(odeproblem(), ExplicitEulerTest())
+
+
+# A nonlinear solve that breaks down throws a `NonlinearSolverException` rather than returning a
+# bad iterate. The time-stepping loop has to catch it, or `integrate` — which allocates the
+# solution internally — would discard the whole trajectory instead of the part that is valid.
+#
+# The vector field goes non-finite past a fixed time rather than blowing up gradually, so the step
+# at which the solve breaks down is pinned down (with a timestep of 0.1 and the stage time of the
+# implicit method at the end of the step, that is n = 4) instead of depending on how an overflow
+# happens to round.
+function breakdown_v(v, t, q, params)
+    v .= t ≥ 0.35 ? Inf : q
+    nothing
+end
+
+breakdown = ODEProblem(breakdown_v, (0.0, 1.0), 0.1, [1.0, 0.0])
+
+sol_breakdown = @test_logs (:warn, r"Nonlinear solver failed at timestep n=4") match_mode = :any integrate(breakdown, ImplicitEuler())
+
+# the steps before the breakdown survive, and the exception did not propagate
+@test all(n -> all(isfinite, sol_breakdown.q[n]), 0:3)

--- a/test/solver_tests.jl
+++ b/test/solver_tests.jl
@@ -1,7 +1,9 @@
 using GeometricIntegratorsBase
 using Test
 
-import GeometricIntegratorsBase: initsolver
+import GeometricIntegratorsBase: default_linesearch, default_options, initsolver
+
+using SimpleSolvers: Backtracking
 
 using ..HarmonicOscillator
 
@@ -14,3 +16,22 @@ caches = CacheDict(prob, TestMethod())
 
 
 @test initsolver(NoSolver(), TestMethod(), caches) == NoSolver()
+
+
+# the untyped `default_linesearch` is the downstream hook and must keep working unchanged,
+# while the typed one builds the method at the working precision directly
+@test default_linesearch() isa Backtracking{Float64}
+@test default_linesearch(TestMethod()) isa Backtracking{Float64}
+@test default_linesearch(Float32) isa Backtracking{Float32}
+@test default_linesearch(Float32, TestMethod()) isa Backtracking{Float32}
+
+# the expansion phase of SimpleSolvers 0.11 is deliberately left off, since every method here
+# solves with `Newton()`, whose direction is already scaled like a Newton step
+@test default_linesearch().expand == false
+@test default_linesearch(Float32).expand == false
+
+
+# a solve whose residual goes nowhere is bounded per time step rather than spending
+# `max_iterations` on every one of them
+@test default_options(TestMethod(), prob).f_stall_window == 50
+@test default_options(TestMethod(), prob).min_iterations == 1

--- a/test/solver_tests.jl
+++ b/test/solver_tests.jl
@@ -1,9 +1,10 @@
 using GeometricIntegratorsBase
 using Test
 
+import GeometricIntegratorsBase: DEFAULT_F_STALL_WINDOW
 import GeometricIntegratorsBase: default_linesearch, default_options, initsolver
 
-using SimpleSolvers: Backtracking
+using SimpleSolvers: Backtracking, F_STALL_REPORT_MINIMUM
 
 using ..HarmonicOscillator
 
@@ -33,5 +34,9 @@ caches = CacheDict(prob, TestMethod())
 
 # a solve whose residual goes nowhere is bounded per time step rather than spending
 # `max_iterations` on every one of them
-@test default_options(TestMethod(), prob).f_stall_window == 50
+@test default_options(TestMethod(), prob).f_stall_window == DEFAULT_F_STALL_WINDOW
 @test default_options(TestMethod(), prob).min_iterations == 1
+
+# the window has to stay above the count below which SimpleSolvers holds the no-progress
+# proportion to be no evidence of anything: giving up on less than it will report on is incoherent
+@test DEFAULT_F_STALL_WINDOW > F_STALL_REPORT_MINIMUM

--- a/test/solver_tests.jl
+++ b/test/solver_tests.jl
@@ -26,6 +26,18 @@ caches = CacheDict(prob, TestMethod())
 @test default_linesearch(Float32) isa Backtracking{Float32}
 @test default_linesearch(Float32, TestMethod()) isa Backtracking{Float32}
 
+@test default_linesearch(BigFloat) isa Backtracking{BigFloat}
+
+# the typed method must not intercept a call meant for the untyped hook: passing a method *type*
+# instead of an instance still resolves to the untyped one, as it did before the typed one existed
+@test default_linesearch(TestMethod) isa Backtracking{Float64}
+@test which(default_linesearch, Tuple{Type{TestMethod}}) !== which(default_linesearch, Tuple{Type{Float32}})
+
+# ... while the constraint stays wide enough for a real type that is not an `AbstractFloat`: the
+# `ForwardDiff.Dual` a caller differentiating through an integration arrives with has to reach the
+# typed method, which is what `T<:Real` rather than `T<:AbstractFloat` buys
+@test which(default_linesearch, Tuple{Type{Rational{Int}}}) === which(default_linesearch, Tuple{Type{Float32}})
+
 # the expansion phase of SimpleSolvers 0.11 is deliberately left off, since every method here
 # solves with `Newton()`, whose direction is already scaled like a Newton step
 @test default_linesearch().expand == false


### PR DESCRIPTION
Bumps `[compat] SimpleSolvers` to `"0.11"` and acts on the three changes in 0.11.0 that reach this package. Version goes to `0.6.0`: the compat entry drops a previously-resolvable dependency version, and two of the changes below alter solver behaviour at the framework default.

Nothing this package used was removed. The one breaking change upstream is `Backtracking` losing its `α₀` key, the `DEFAULT_ARMIJO_α₀` constant and the positional `Backtracking{T}(α₀, c₁, c₂, p[, τ_ulps])` form, none of which appear here — `default_linesearch` calls the keyword form. The `NonlinearSolver(method, x, F!, y; kwargs...)` constructor of `initsolver` still exists and is now a delegation to the new `NonlinearProblem` form, with no behaviour change. The export list is purely additive. So the bump itself is mechanical.

## A non-finite direction now throws (`src/integrate.jl`)

0.10.1 tested `any(isnan, direction)`; 0.11.0 tests `all(isfinite, …)` and throws `NonlinearSolverException`. An *overflowed* direction used to pass every guard the solvers had and stall silently, because it was handed to a damping that cannot shorten it — `Inf * nan_factor` is `Inf`.

The time-stepping loop now catches that exception, warns naming the timestep, and breaks, exactly as the adjacent `isnan(curstate)` check does. Left to propagate it would discard the whole trajectory, since `integrate(problem, method)` allocates the solution internally and the caller never gets a reference to it. The `break` precedes the `copy!`, so the solution holds valid data up to `n-1`. Only that one exception type is caught — anything else is a bug and is rethrown.

The warning has to say *where* the valid data ends, because nothing in the solution marks it. `Solution` allocates through `DataSeries(x, ntime) = [zero(x) for _ in 0:ntime]`, so the entries from `n` on are zeros — for most problems indistinguishable from computed data. The NaN branch does not have this problem, since it copies first and the offending entry carries a NaN a caller can see; the exception branch leaves no marker at all.

```
┌ Warning: Nonlinear solver failed at timestep n=4: non-finite direction vector. The solution is
│ valid up to n=3; later entries were never computed.
q = [[1.0, 0.0], [1.111…], [1.234…], [1.371…], [0.0, 0.0], …]
```

## `f_stall_window` in `default_options` (`src/solvers.jl`)

The criterion 0.11.0 added for the case `max_stalls` cannot see: the residual sits on a floor above `f_abstol` while the iterate keeps moving normally, so no criterion fires and the solve spends `max_iterations` — 1000 by default — on *every* time step.

50 is the conservative point. At SimpleSolvers' `f_stall_factor = 0.5` it gives up only on a linear rate ρ > 2^(-1/50) ≈ 0.986, i.e. on a residual that is essentially flat — and every method here solves with `Newton()`. It also stays above `SimpleSolvers.F_STALL_REPORT_MINIMUM = 10`, below which SimpleSolvers itself holds the no-progress proportion to be no evidence of anything; giving up on less than the package will report on would be incoherent. Giving up and converging remain mutually exclusive (`no_progress` is gated on `!residual_small`), the solve still reports the residual achieved against the tolerance requested, and `default_options` is merged rather than replaced, so a caller who disagrees overrides it with one keyword.

The one case it is *not* conservative for is stated as a limitation rather than left implicit. `default_options` is reached from the `GeometricIntegrator` constructor that takes an arbitrary `solvermethod`, so "every method here solves with `Newton()`" does not cover a caller passing `Picard()`, or a downstream method: a fixed-point iteration converging linearly at a rate close to the threshold — a stiff problem near the Picard convergence limit — is now cut off where it previously converged. Such a caller has to raise the window, and the value is `DEFAULT_F_STALL_WINDOW`, a named constant rather than a literal buried in a NamedTuple, so it is discoverable. The ρ derivation lives in `SimpleSolvers.F_STALL_WINDOW`, which states it verbatim, and is pointed at rather than copied, so it cannot drift from upstream's defaults.

## `default_linesearch` is now type-aware (`src/solvers.jl`)

`Backtracking()` is always `Backtracking{Float64}`, so a `Float32` integration made the `Linesearch` constructor do a `change_precision` the caller could have avoided. The untyped method is kept unchanged, because its signature is the downstream hook GeometricIntegrators calls for DIRK. The type parameter is constrained to `T<:Number`, so `default_linesearch(String)` fails at the signature rather than inside `Backtracking`.

The rationale is a docstring rather than a comment, since this is an unexported function that nothing in this package calls — the docstring records that too, and that the tests are what keep both signatures alive.

## Not done deliberately

`Backtracking`'s new expansion phase is left off, and the source says why: it is opt-in upstream because it costs a merit evaluation — a full residual evaluation here — on a direction whose scale is wrong, and gains nothing on one whose scale is right, a Newton step already sitting at its model minimum. Enabling it in a shared hook would also change DIRK trajectories downstream.

## Testing

- Full suite green (655 assertions) against SimpleSolvers v0.11.0, confirmed from `Pkg.test`'s own resolution rather than the ambient environment.
- The exception handling is tested **directly**, on a method that throws at a chosen time, built on the fake-integrator harness `test/integrator_tests.jl` already had. That pins down which step fails, what the surviving steps hold, what the rest of the solution holds, and that any other exception is rethrown. Going only through a real solve would have coupled the test to upstream's failure chain — Inf residual → NaN Jacobian → NaN direction → exception — and so to a rewording or an earlier rejection upstream.
- A real `Newton()` solve reaching that rejection is kept as the complement. Its vector field goes non-finite past a fixed time rather than blowing up gradually, so the step it trips on is pinned down (n = 4) rather than depending on how an overflow rounds.
- Both "the earlier steps survive" assertions are exact values, not `isfinite`: the zeros an early `break` leaves behind are finite too, so an `isfinite` assertion passes whether or not those steps were lost. Implicit Euler on q̇ = q with h = 0.1 gives qₙ₊₁ = qₙ / (1 - h) exactly.
- New tests also cover both `default_linesearch` forms, the new option, and that the window stays above `F_STALL_REPORT_MINIMUM`.
- Everything else passes unedited, including the `@test_nowarn` tripwires and the trajectory-error assertions — the check that the healthy path is untouched. Upstream reports bit-identical downstream trajectories.
- Docs build renders (the missing-docstring warnings are pre-existing and `warnonly`-gated; the two new docstrings join that list, as there is no solvers page in `docs/src` to hang them on).
- `f_stall_window` verified to reach the solver's `config`, and a caller's override verified to win through the merge while `min_iterations = 1` survives.

One limit worth stating: the *early stop* itself is not verified end-to-end here. A residual with a genuine floor and a non-singular Jacobian is not a short fixture — the obvious candidates degenerate into a singular Jacobian, which is a different failure path. The `no_progress` criterion is tested upstream; what this PR verifies is that the option is accepted, reaches `config`, is overridable, and leaves the healthy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
