### PR TITLE
Document default_options and render solvers.jl in the manual

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricIntegratorsBase"
 uuid = "71212ab4-08a2-48eb-a02b-4cbad0e9c44a"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,7 @@ makedocs(;
         "Home" => "index.md",
         "Extrapolation Methods" => "extrapolation.md",
         "Integrators" => "integrators.md",
+        "Solvers" => "solvers.md",
         "Dependencies" => [
             "Equations" => "deps/equations.md",
             "Problems" => "deps/problems.md",

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,0 +1,7 @@
+# Solvers
+
+```@autodocs
+Modules = [GeometricIntegratorsBase]
+Order   = [:constant, :type, :macro, :function]
+Pages   = ["solvers.jl"]
+```

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -48,6 +48,39 @@ say. Every method in this package uses `Newton()`, but `default_options` is reac
 """
 const DEFAULT_F_STALL_WINDOW = 50
 
+"""
+    default_options(method, problem)
+
+The options a `method` is solved with unless the caller says otherwise. They reach the nonlinear
+solver as the keyword arguments of `initsolver`.
+
+`GeometricIntegrator` *merges* them with the options it is handed —
+`merge(default_options(method, problem), options)` in `src/integrator.jl` — so a caller who sets
+one of them keeps the rest. Replacing the whole bundle instead, as this package did up to 0.4.x,
+meant that passing any option at all silently dropped every default not restated alongside it.
+
+The bundle is queried on the `initmethod`-specialised method, so `solversize` below sees the
+concrete integrator rather than the method the caller named: `LobattoIIIA(2)` on a 2-dof ODE
+arrives here as a `DIRK` with `solversize == 2`, `RadauIIA(2)` as an `IRK` with `solversize == 4`.
+
+* `min_iterations = 1` — SimpleSolvers tests its stopping criteria *before* the first step, so
+  without this a solve whose initial guess already satisfies them takes no step at all, and the
+  extrapolated initial guesses used throughout this package are regularly that good.
+* `f_abstol` scales with the size of the solver system: `max(8, solversize(method, problem))`
+  residual components at `eps(datatype(problem))` apiece, because the norm of a residual sitting
+  on its round-off floor grows with the number of components it sums. `f_reltol` is no substitute
+  — it is anchored at the *initial* residual, so a good initial guess makes the relative gate
+  tighter rather than looser. The floor is 8 and not 2 because the smallest solver systems are
+  genuinely tiny: at `2eps ≈ 4.4e-16` the `DIRK` case above sits below its own round-off floor
+  and stagnates, whereas `8eps ≈ 1.78e-15` clears every floor measured downstream and is what
+  this package defaulted to before the size factor existed.
+* `f_stall_window` — see [`DEFAULT_F_STALL_WINDOW`](@ref).
+
+Overriding this is how a downstream family of methods changes solver options in one place rather
+than at every call site. The two overrides that existed for `f_abstol` — one for the implicit
+Runge-Kutta families, one for SPARK — were both removed once the size scaling landed, since the
+sized value lands above the residual floor of each of them.
+"""
 default_options(method::GeometricMethod, problem::GeometricProblem) = (
     min_iterations=1,
     f_abstol=max(8, solversize(method, problem)) * eps(datatype(problem)),


### PR DESCRIPTION
`DEFAULT_F_STALL_WINDOW`'s docstring links to ``[`default_options`](@ref)``, which had no
docstring, so the reference had no target.

Nothing broke here, because every `@autodocs` block in this manual is `Pages`-filtered and
`src/solvers.jl` is in none of them — the docstring was never expanded and its links were never
checked. GeometricIntegrators pulls the same docstrings in through an *unfiltered* block, so its
documentation build is where the dangling reference surfaced:

```
Cannot resolve @ref for md"[`default_options`](@ref)" in docs/src/modules/base.md.
- No docstring found in doc for binding `GeometricIntegratorsBase.default_options`.
```

(https://github.com/JuliaGNI/GeometricIntegrators.jl/actions/runs/31696729390 — `:cross_references`
is inside that repo's `Documenter.except(...)`, so the build terminated before rendering.)

## Changes

- **`default_options` gets a docstring** (`src/solvers.jl`): the `merge` semantics against
  caller-supplied options, that the bundle is queried on the `initmethod`-specialised method so
  `solversize` sees the concrete integrator, and the reasoning behind each of `min_iterations`,
  the size-scaled `f_abstol` and `f_stall_window`.
- **New Solvers page** (`docs/src/solvers.md`, registered in `docs/make.jl`) rendering
  `solvers.jl`. `:cross_references` is already an error in this repo's `warnonly`, so a dangling
  reference in `default_linesearch`, `DEFAULT_F_STALL_WINDOW` or `default_options` now fails
  *here* rather than only downstream.
- **`Project.toml` → 0.6.1**, so the fix can reach the failing downstream build (its compat is
  `"0.6"` and neither repo commits a `Manifest.toml`, so no downstream change is needed).

Every `@ref` in the new docstring points at a binding rendered on the new page; `solversize`,
`GeometricMethod` and `GeometricIntegrator` are named in plain backticks, since none of them
appears on a page of this manual.

## Verification

- `julia --project=docs docs/make.jl` here: reaches `RenderDocument` with no cross-reference
  error; the Solvers page lists all three names.
- GeometricIntegrators' full docs build against this branch dev'd in: exits 0, and the reference
  resolves to the `default_options` anchor in `modules/base.html`. That is the exact failure from
  the run above.
- Test suite unchanged and passing (docs/docstring-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)